### PR TITLE
Add arm64 compilation for mac dylib

### DIFF
--- a/build/darwin_multiarch/Makefile
+++ b/build/darwin_multiarch/Makefile
@@ -1,0 +1,24 @@
+INCLUDEDIR = ../../src/include
+SRCDIR = ../../src
+LIBRARY = libswnfd.dylib
+OBJS = nfd_cocoa.o nfd_common.o nfd_wizards.o
+
+CCOPTS = -DNDEBUG -O3 -I$(INCLUDEDIR) -arch arm64 -arch x86_64 -fPIC
+LDOPTS = -framework Foundation -framework AppKit -arch arm64 -arch x86_64 -fPIC -dynamiclib
+
+all: $(LIBRARY)
+
+.PHONY: clean
+clean:
+	rm -f $(LIBRARY) $(OBJS)
+
+%.o: $(SRCDIR)/%.m
+	clang $(CCOPTS) -o $@ -c $<
+
+%.o: $(SRCDIR)/%.c
+	clang $(CCOPTS) -o $@ -c $<
+
+$(LIBRARY): $(OBJS)
+	clang $(LDOPTS) -o $@ $(OBJS)
+
+

--- a/link_macos.sh
+++ b/link_macos.sh
@@ -2,8 +2,13 @@
 
 cd "$(dirname "$0")"
 
-pushd build/gmake_macosx
+pushd build/darwin_multiarch
 make
 popd
 
-clang -Wall -fPIC -O2 -shared -o build/lib/Release/x64/libswnfd.dylib src/nfd_wizards.c -Isrc/include build/lib/Release/x64/libnfd.a -framework Foundation -framework Appkit
+# the result is in build/darwin_multiarch/libswnfd.dylib
+
+# maintain backwards compatiblity with stuff that expects the file in the old location 
+mkdir -p build/lib/Release/x64
+cp build/darwin_multiarch/libswnfd.dylib build/lib/Release/x64/libswnfd.dylib
+


### PR DESCRIPTION
In retrospect this doesn't even need a Makefile, but I didn't know that until I went down the path of trying to cut out the unnecessary chaff that all the lua premake shit does. I did not expect it to be all chaff, but it literally was just compiling one .c file and one .m file into a static lib. At least you can kind of tell now.

(One thing that is different from the default build scripts for OSX is that I changed from `-O2` to `-O3`. It is almost certainly completely inconsequential for a file dialog opener.)

This should have no impact on downstream dependencies but I don't have an Intel mac to check.